### PR TITLE
Mac training program - Delete - View past programs

### DIFF
--- a/Controllers/TrainingProgramsController.cs
+++ b/Controllers/TrainingProgramsController.cs
@@ -65,7 +65,43 @@ namespace BangazonWorkforce.Controllers
             }
         }
 
-       // GET: TrainingPrograms/Details/1
+        // GET: Training Programs - only past Dates
+        public ActionResult History()
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    // This SQL query is only getting training programs that start after today
+                    cmd.CommandText = @"SELECT Id, Name, StartDate, EndDate, MaxAttendees 
+                                      FROM TrainingProgram
+                                      WHERE EndDate < GETDATE()";
+
+
+                    var reader = cmd.ExecuteReader();
+                    var trainingPrograms = new List<TrainingProgram>();
+
+                    while (reader.Read())
+                    {
+                        var trainingProgram = new TrainingProgram()
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Name = reader.GetString(reader.GetOrdinal("Name")),
+                            StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
+                            EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
+                            MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees")),
+
+                        };
+                        trainingPrograms.Add(trainingProgram);
+                    }
+                    reader.Close();
+                    return View(trainingPrograms);
+                }
+            }
+        }
+
+        // GET: TrainingPrograms/Details/1
         public ActionResult Details(int id)
         {
             var trainingProgram = GetTrainingProgramById(id);

--- a/Controllers/TrainingProgramsController.cs
+++ b/Controllers/TrainingProgramsController.cs
@@ -73,7 +73,7 @@ namespace BangazonWorkforce.Controllers
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
-                    // This SQL query is only getting training programs that start after today
+                    // This SQL query is only getting training programs that End before today
                     cmd.CommandText = @"SELECT Id, Name, StartDate, EndDate, MaxAttendees 
                                       FROM TrainingProgram
                                       WHERE EndDate < GETDATE()";
@@ -224,8 +224,10 @@ namespace BangazonWorkforce.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult Delete(int id, TrainingProgram trainingProgram)
         {
+            DeleteEmployeeTraining(id);
             try
             {
+                
                 using (SqlConnection conn = Connection)
                 {
                     conn.Open();
@@ -246,7 +248,21 @@ namespace BangazonWorkforce.Controllers
                 return View();
             }
         }
+        // this is a method to delete employee - training relationships when deleting a program 
+        private void DeleteEmployeeTraining(int id)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"  DELETE FROM EmployeeTraining WHERE TrainingProgramId = @TrainingProgramId";
+                    cmd.Parameters.Add(new SqlParameter("@TrainingProgramId", id));
 
+                    int rowsAffected = cmd.ExecuteNonQuery();
+                }
+            }
+        }
 
         private TrainingProgram GetTrainingProgramById(int id)
         {

--- a/Controllers/TrainingProgramsController.cs
+++ b/Controllers/TrainingProgramsController.cs
@@ -175,40 +175,40 @@ namespace BangazonWorkforce.Controllers
             }
         }
 
-        //        // GET: TrainingPrograms/Delete/5
-        //        public ActionResult Delete(int id)
-        //        {
-        //            var instructor = GetInstructorById(id);
-        //            return View(instructor);
-        //        }
+        // GET: TrainingPrograms/Delete/5
+        public ActionResult Delete(int id)
+        {
+            var trainingProgram = GetTrainingProgramById(id);
+            return View(trainingProgram);
+        }
 
-        //        // POST: Instructors/Delete/5
-        //        [HttpPost]
-        //        [ValidateAntiForgeryToken]
-        //        public ActionResult Delete(int id, Instructor instructor)
-        //        {
-        //            try
-        //            {
-        //                using (SqlConnection conn = Connection)
-        //                {
-        //                    conn.Open();
-        //                    using (SqlCommand cmd = conn.CreateCommand())
-        //                    {
-        //                        cmd.CommandText = "DELETE FROM Instructor WHERE Id = @id";
-        //                        cmd.Parameters.Add(new SqlParameter("@id", id));
+        // POST: TrainingPrograms/Delete/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Delete(int id, TrainingProgram trainingProgram)
+        {
+            try
+            {
+                using (SqlConnection conn = Connection)
+                {
+                    conn.Open();
+                    using (SqlCommand cmd = conn.CreateCommand())
+                    {
+                        cmd.CommandText = "DELETE FROM TrainingProgram WHERE Id = @id";
+                        cmd.Parameters.Add(new SqlParameter("@id", id));
 
-        //                        cmd.ExecuteNonQuery();
+                        cmd.ExecuteNonQuery();
 
-        //                    }
-        //                }
+                    }
+                }
 
-        //                return RedirectToAction(nameof(Index));
-        //            }
-        //            catch (Exception ex)
-        //            {
-        //                return View();
-        //            }
-        //        }
+                return RedirectToAction(nameof(Index));
+            }
+            catch (Exception ex)
+            {
+                return View();
+            }
+        }
 
 
         private TrainingProgram GetTrainingProgramById(int id)

--- a/Views/TrainingPrograms/Delete.cshtml
+++ b/Views/TrainingPrograms/Delete.cshtml
@@ -1,0 +1,50 @@
+﻿@model BangazonWorkforce.Models.TrainingProgram
+
+@{
+    ViewData["Title"] = "Delete";
+}
+
+<h1>Delete</h1>
+
+<h3>Are you sure you want to delete this?</h3>
+<div>
+    <h4>TrainingProgram</h4>
+    <hr />
+    <dl class="row">
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Id)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Id)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Name)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Name)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.StartDate)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.StartDate)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.EndDate)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.EndDate)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.MaxAttendees)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.MaxAttendees)
+        </dd>
+    </dl>
+    
+    <form asp-action="Delete">
+        <input type="submit" value="Delete" class="btn btn-danger" /> |
+        <a asp-action="Index">Back to List</a>
+    </form>
+</div>

--- a/Views/TrainingPrograms/Details.cshtml
+++ b/Views/TrainingPrograms/Details.cshtml
@@ -43,13 +43,15 @@
         <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Employees) 
         </dt>
+    <dd class="col-sm-10">
         @foreach (Employee employee in Model.Employees)
         {
-    <dd class="col-sm-10">
-        @Html.DisplayFor(Employee => employee.FirstName)
-        @Html.DisplayFor(Employee => employee.LastName)
-    </dd>
+            <div>
+                <span> @Html.DisplayFor(Employee => employee.FirstName)</span>
+                <span>@Html.DisplayFor(Employee => employee.LastName)</span>
+            </div>
         }
+    </dd>
         </dl>
 </div>
 <div>

--- a/Views/TrainingPrograms/Details.cshtml
+++ b/Views/TrainingPrograms/Details.cshtml
@@ -57,7 +57,11 @@
         if it is, the user is given the option to edit the details*@
     @if (Model.StartDate > DateTime.Now)
     {
-        @Html.ActionLink("Edit", "Edit", new { id = Model.Id })
+        <div>
+
+            @Html.ActionLink("Edit", "Edit", new { id = Model.Id })
+            |
+        </div>
     }
-    |<a asp-action="Index">Back to List</a>
+    <a asp-action="Index">Back to List</a>
 </div>

--- a/Views/TrainingPrograms/History.cshtml
+++ b/Views/TrainingPrograms/History.cshtml
@@ -1,0 +1,58 @@
+﻿@model IEnumerable<BangazonWorkforce.Models.TrainingProgram>
+
+@{
+    ViewData["Title"] = "History";
+}
+
+<h1>Previous Training Programs</h1>
+
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                @Html.DisplayNameFor(model => model.Id)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Name)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.StartDate)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.EndDate)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.MaxAttendees)
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model) {
+        <tr>
+            <td>
+                @Html.DisplayFor(modelItem => item.Id)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Name)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.StartDate)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.EndDate)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.MaxAttendees)
+            </td>
+            <td>
+                @Html.ActionLink("Details", "Details", new {  id=item.Id  }) 
+            </td>
+        </tr>
+}
+    </tbody>
+</table>
+<div>
+    <a asp-action="Index">View Future Programs</a>
+</div>

--- a/Views/TrainingPrograms/Index.cshtml
+++ b/Views/TrainingPrograms/Index.cshtml
@@ -58,3 +58,6 @@
         }
     </tbody>
 </table>
+<p>
+    <a asp-action="History">View Past Programs</a>
+</p>


### PR DESCRIPTION
# Description
The user can now delete future programs, view a list of past programs, and view a list of people who attended past programs.                
Closes #11 
Closes #14 
Closes #15
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
When viewing the list of programs or in the details view of the project you should see the `delete` option. Delete an event and confirm that it is deleted from the database. 

While view the list of programs you should see an option towards the bottom to `view past programs` click this link and you should be given a list of all training programs that have ended before today's date. Confirm that you are not given the `delete` or `edit` options in either the list view or the details view. 

Lastly, you should see a list of the employees that attended these events while looking at the details page. 

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
