### PR TITLE
Mac assign employee training

### DIFF
--- a/Controllers/EmployeesController.cs
+++ b/Controllers/EmployeesController.cs
@@ -201,8 +201,22 @@ namespace BangazonWorkforce.Controllers
             }
         }
 
+        //this is getting the info to build the form to assign the employee to a training program
+        //GET: Employees/Create
+        public ActionResult Assign(int id)
+        {
+            var employee = GetEmployeeById(id);
+            var programOptions = GetProgramOptions();
+            var viewModel = new EmployeeTrainingAssignViewModel()
+            {
+                ProgramOptions = programOptions,
+                Name = employee.FirstName + " " + employee.LastName,
+                
+            };
+            return View(viewModel);
+        }
 
-         //return the FORM
+        //return the FORM
         // GET: Employees/Edit/5
         public ActionResult Edit(int id)
         {
@@ -230,6 +244,8 @@ namespace BangazonWorkforce.Controllers
             return View(viewModel);
 
         }
+
+
 
 
         //runs the POST
@@ -458,7 +474,35 @@ namespace BangazonWorkforce.Controllers
 
 
 
-
         }
+            private List<SelectListItem> GetProgramOptions()
+            {
+
+                using (SqlConnection conn = Connection)
+                {
+                    conn.Open();
+                    using (SqlCommand cmd = conn.CreateCommand())
+                    {
+                        cmd.CommandText = "SELECT Id, Name FROM TrainingProgram";
+
+                        var reader = cmd.ExecuteReader();
+                        var options = new List<SelectListItem>();
+
+                        while (reader.Read())
+                        {
+                            var option = new SelectListItem()
+                            {
+                                Text = reader.GetString(reader.GetOrdinal("Name")),
+                                Value = reader.GetInt32(reader.GetOrdinal("Id")).ToString(),
+                            };
+
+                            options.Add(option);
+
+                        }
+                        reader.Close();
+                        return options;
+                    }
+                }
+            }
     }
 }

--- a/Controllers/EmployeesController.cs
+++ b/Controllers/EmployeesController.cs
@@ -202,7 +202,7 @@ namespace BangazonWorkforce.Controllers
         }
 
         //this is getting the info to build the form to assign the employee to a training program
-        //GET: Employees/Create
+        //GET: Employees/Assign
         public ActionResult Assign(int id)
         {
             var employee = GetEmployeeById(id);
@@ -211,9 +211,48 @@ namespace BangazonWorkforce.Controllers
             {
                 ProgramOptions = programOptions,
                 Name = employee.FirstName + " " + employee.LastName,
+                EmployeeId = id,
+               
                 
             };
             return View(viewModel);
+        }
+
+        //POST: Employees/Assign
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        //public ActionResult Create(EmployeeEditViewModel employee)
+        public ActionResult Assign(EmployeeTraining employeeTraining, EmployeeTrainingAssignViewModel employee)
+        {
+            try
+            //debug here
+            {
+                using (SqlConnection conn = Connection)
+                {
+                    conn.Open();
+                    using (SqlCommand cmd = conn.CreateCommand())
+                    {
+                        cmd.CommandText = @"INSERT INTO EmployeeTraining (TrainingProgramId, EmployeeId)
+                                            OUTPUT INSERTED.Id
+                                            VALUES (@TrainingProgramId, @EmployeeId)";
+
+                        cmd.Parameters.Add(new SqlParameter("@TrainingProgramId", employeeTraining.TrainingProgramId));
+                        cmd.Parameters.Add(new SqlParameter("@EmployeeId", employee.Id));
+                        
+
+                        var id = (int)cmd.ExecuteScalar();
+                        //employeeTraining.EmployeeId = id;
+
+                        // this sends you back to index after created
+                        return RedirectToAction("Details", new { employee.Id });
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // debug here
+                return View();
+            }
         }
 
         //return the FORM

--- a/Controllers/EmployeesController.cs
+++ b/Controllers/EmployeesController.cs
@@ -483,7 +483,13 @@ namespace BangazonWorkforce.Controllers
                     conn.Open();
                     using (SqlCommand cmd = conn.CreateCommand())
                     {
-                        cmd.CommandText = "SELECT Id, Name FROM TrainingProgram";
+                        cmd.CommandText = @"SELECT tp.Id, tp.[Name], tp.MaxAttendees, et.TrainingProgramId, COUNT(et.EmployeeId) 
+                                            FROM TrainingProgram tp
+                                            LEFT JOIN EmployeeTraining et 
+                                            ON tp.Id =  et.TrainingProgramId 
+                                            WHERE tp.StartDate > GETDATE()
+                                            AND tp.MaxAttendees > et.EmployeeId
+                                            GROUP BY tp.[Name], et.TrainingProgramId, tp.Id,  tp.MaxAttendees";
 
                         var reader = cmd.ExecuteReader();
                         var options = new List<SelectListItem>();

--- a/Models/ViewModels/EmployeeTrainingAssignViewModel.cs
+++ b/Models/ViewModels/EmployeeTrainingAssignViewModel.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BangazonWorkforce.Models.ViewModels
+{
+    public class EmployeeTrainingAssignViewModel
+    {
+        [Display(Name = "Id")]
+        public int Id { get; set; }
+
+        [Display(Name = "Employee Id")]
+        public int EmployeeId { get; set; }
+
+        [Display(Name = "Name")]
+        public string Name { get; set; }
+
+        [Display(Name = "Training Programs")]
+        public int TrainingProgramId { get; set; }
+
+
+
+        public List<SelectListItem> ProgramOptions { get; set; }
+
+    }
+}

--- a/Models/ViewModels/EmployeeTrainingAssignViewModel.cs
+++ b/Models/ViewModels/EmployeeTrainingAssignViewModel.cs
@@ -20,6 +20,7 @@ namespace BangazonWorkforce.Models.ViewModels
 
         [Display(Name = "Training Programs")]
         public int TrainingProgramId { get; set; }
+        public int EmployeeCount { get; set; }
 
 
 

--- a/Views/Employees/Assign.cshtml
+++ b/Views/Employees/Assign.cshtml
@@ -26,14 +26,14 @@
 
             </div>
             <div class="form-group">
-                <input type="submit" value="Create" class="btn btn-primary" />
+                <input type="submit" value="Assign" class="btn btn-primary" />
             </div>
         </form>
     </div>
 </div>
 
 <div>
-    <a asp-action="Index">Back to List</a>
+    <a asp-action="Index">Back to Index</a>
 </div>
 
 @section Scripts {

--- a/Views/Employees/Assign.cshtml
+++ b/Views/Employees/Assign.cshtml
@@ -1,0 +1,41 @@
+﻿@model BangazonWorkforce.Models.ViewModels.EmployeeTrainingAssignViewModel
+
+@{
+    ViewData["Title"] = "Assign";
+}
+
+<h1>Assign</h1>
+
+<h4>Assign  @($"{Model.Name}") to Training Program</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Assign">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+
+                <label asp-for="TrainingProgramId" class="control-label"></label>
+
+                <select asp-for="TrainingProgramId" asp-items="@Model.ProgramOptions" class="form-control">
+
+                    <option>Please choose a program</option>
+
+                </select>
+
+                <span asp-validation-for="TrainingProgramId" class="text-danger"></span>
+
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Create" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index">Back to List</a>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/Views/Employees/Details.cshtml
+++ b/Views/Employees/Details.cshtml
@@ -74,5 +74,6 @@
 </div>
 <div>
     @Html.ActionLink("Edit", "Edit", new { id = Model.Id }) |
+    @Html.ActionLink("Assign", "Assign", new { id = Model.Id }) |
     <a asp-action="Index">Back to List</a>
 </div>


### PR DESCRIPTION
# Description
Added an assignment method in `employeeController` and added an assignment view. This allows the user to assign an employee to a training program when viewing said employees detail page
Closes half of #16 - need to work on the multiselect
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
Navigate to an employees `detail` page. You should see an option to `assign` . Click this link and you will be taken to a form to assign the employee to a training program. The drop down should have a list of all training programs that are in the future and that are not at max capacity. Make a selection and click `assign`. Now if you navigate to that training program's detail view you should see that employee in the list of attending employees.  
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
