### PR TITLE
Training Program titles and attendee count

### DIFF
--- a/Models/ViewModels/TrainingProgramDetailViewModel.cs
+++ b/Models/ViewModels/TrainingProgramDetailViewModel.cs
@@ -19,5 +19,11 @@ namespace BangazonWorkforce.ViewModels
         public int MaxAttendees { get; set; }
         [Display(Name = "Employees Attending")]
         public List<Employee> Employees { get; set; }
+        public int EmployeeCount { get
+            {
+               return Employees.Count;
+            }
+        }
+
     }
 }

--- a/Views/TrainingPrograms/Create.cshtml
+++ b/Views/TrainingPrograms/Create.cshtml
@@ -6,7 +6,7 @@
 
 <h1>Create</h1>
 
-<h4>TrainingProgram</h4>
+<h4>Add New Training Program</h4>
 <hr />
 <div class="row">
     <div class="col-md-4">

--- a/Views/TrainingPrograms/Delete.cshtml
+++ b/Views/TrainingPrograms/Delete.cshtml
@@ -8,15 +8,9 @@
 
 <h3>Are you sure you want to delete this?</h3>
 <div>
-    <h4>TrainingProgram</h4>
+    <h4>@Model.Name</h4>
     <hr />
     <dl class="row">
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Id)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Id)
-        </dd>
         <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.Name)
         </dt>

--- a/Views/TrainingPrograms/Details.cshtml
+++ b/Views/TrainingPrograms/Details.cshtml
@@ -7,7 +7,7 @@
 <h1>Details</h1>
 
 <div>
-    <h4>TrainingProgramDetailViewModel</h4>
+    <h4>@Model.Name</h4>
     <hr />
     <dl class="row">
         <dt class="col-sm-2">
@@ -41,7 +41,7 @@
             @Html.DisplayFor(model => model.MaxAttendees)
         </dd>
         <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.Employees) 
+            @Html.DisplayNameFor(model => model.Employees) (@Html.DisplayFor(model => model.EmployeeCount))
         </dt>
     <dd class="col-sm-10">
         @foreach (Employee employee in Model.Employees)

--- a/Views/TrainingPrograms/Edit.cshtml
+++ b/Views/TrainingPrograms/Edit.cshtml
@@ -6,7 +6,7 @@
 
 <h1>Edit</h1>
 
-<h4>TrainingProgram</h4>
+<h4>@Model.Name</h4>
 <hr />
 <div class="row">
     <div class="col-md-4">


### PR DESCRIPTION

# Description
Fixed issue where while viewing any of the `training program` views the title would be "TrainingProgram." Now displaying name of the Program

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions
Navigate to every training program view (`details`, `Edit`, `delete`, `create`) and confirm that there are no wrong titles. I also added a count of people attending next to the "employees attending" header on the details view
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
